### PR TITLE
Missing junit-platform dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,7 @@ dependencies {
     simulationRelease wpi.sim.enableRelease()
 
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'
+    testImplementation 'org.junit.platform:junit-platform-launcher:1.8.2'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 


### PR DESCRIPTION
Adding a dependency, VSCode was spitting out an error due to it missing